### PR TITLE
コミュニティおよびユーザー詳細のtableを追加

### DIFF
--- a/app/models/community.rb
+++ b/app/models/community.rb
@@ -1,0 +1,4 @@
+class Community < ApplicationRecord
+  has_many :user_communities
+  has_many :users, through: :user_communities
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,7 @@ class User < ApplicationRecord
   validates :account, presence: true, uniqueness: { case_sensitive: false }
   has_many :articles
   has_one :user_detail
+
+  has_many :user_communities
+  has_many :communities, through: :user_communities
 end

--- a/app/models/user_community.rb
+++ b/app/models/user_community.rb
@@ -1,0 +1,4 @@
+class UserCommunity < ApplicationRecord
+  belongs_to :user
+  belongs_to :community
+end

--- a/db/migrate/20220207150857_create_communities.rb
+++ b/db/migrate/20220207150857_create_communities.rb
@@ -1,0 +1,10 @@
+class CreateCommunities < ActiveRecord::Migration[6.0]
+
+  def change
+    create_table :communities do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220207151209_create_user_communities.rb
+++ b/db/migrate/20220207151209_create_user_communities.rb
@@ -1,0 +1,10 @@
+class CreateUserCommunities < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_communities do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :community, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_07_143825) do
+ActiveRecord::Schema.define(version: 2022_02_07_151209) do
 
   create_table "articles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "title"
@@ -19,6 +19,21 @@ ActiveRecord::Schema.define(version: 2022_02_07_143825) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
+  end
+
+  create_table "communities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_communities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "community_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["community_id"], name: "index_user_communities_on_community_id"
+    t.index ["user_id"], name: "index_user_communities_on_user_id"
   end
 
   create_table "user_details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
@@ -39,5 +54,7 @@ ActiveRecord::Schema.define(version: 2022_02_07_143825) do
   end
 
   add_foreign_key "articles", "users"
+  add_foreign_key "user_communities", "communities"
+  add_foreign_key "user_communities", "users"
   add_foreign_key "user_details", "users"
 end


### PR DESCRIPTION
## 概要
- communities tableを追加
- user_details_tableを追加
- 上記 table との relation を各 model で設定
- 中間テーブルの作成